### PR TITLE
Feature/#93 change lobby list style

### DIFF
--- a/src/components/Canvas.tsx
+++ b/src/components/Canvas.tsx
@@ -148,6 +148,7 @@ const Canvas: React.VFC<Props> = (props) => {
             top: "5%",
             left: "8%",
             color: theme.palette.secondary.main,
+            fontFamily: ["Neonderthaw", "cursive"].join(","),
           }}
         >
           Oekaki App

--- a/src/components/UserAccount.tsx
+++ b/src/components/UserAccount.tsx
@@ -1,0 +1,35 @@
+import React from "react";
+import Box from "@mui/material/Box";
+import ListItem from "@mui/material/ListItem";
+import ListItemText from "@mui/material/ListItemText";
+import ListItemAvatar from "@mui/material/ListItemAvatar";
+import Avatar from "@mui/material/Avatar";
+import PersonIcon from "@mui/icons-material/Person";
+import theme from "../styles";
+
+type Props = {
+  primary: string;
+};
+
+const UserAccount: React.VFC<Props> = ({ primary }) => (
+  <Box
+    sx={{
+      bgcolor: theme.palette.success.main,
+      m: 1,
+      p: 1,
+      borderRadius: "1rem",
+      boxShadow: 3,
+    }}
+  >
+    <ListItem>
+      <ListItemAvatar>
+        <Avatar sx={{ color: "white" }}>
+          <PersonIcon />
+        </Avatar>
+      </ListItemAvatar>
+      <ListItemText primary={primary} />
+    </ListItem>
+  </Box>
+);
+
+export default UserAccount;

--- a/src/components/UserAccount.tsx
+++ b/src/components/UserAccount.tsx
@@ -8,10 +8,10 @@ import PersonIcon from "@mui/icons-material/Person";
 import theme from "../styles";
 
 type Props = {
-  primary: string;
+  userName: string;
 };
 
-const UserAccount: React.VFC<Props> = ({ primary }) => (
+const UserAccount: React.VFC<Props> = ({ userName }) => (
   <Box
     sx={{
       bgcolor: theme.palette.success.main,
@@ -27,7 +27,7 @@ const UserAccount: React.VFC<Props> = ({ primary }) => (
           <PersonIcon />
         </Avatar>
       </ListItemAvatar>
-      <ListItemText primary={primary} />
+      <ListItemText primary={userName} />
     </ListItem>
   </Box>
 );

--- a/src/components/UserList.tsx
+++ b/src/components/UserList.tsx
@@ -4,7 +4,9 @@ import List from "@mui/material/List";
 import ListItem from "@mui/material/ListItem";
 import ListItemText from "@mui/material/ListItemText";
 import ListItemAvatar from "@mui/material/ListItemAvatar";
+import IconButton from "@mui/material/IconButton";
 import Avatar from "@mui/material/Avatar";
+import StarsIcon from "@mui/icons-material/Stars";
 import PersonIcon from "@mui/icons-material/Person";
 import theme from "../styles";
 import UserAccount from "./UserAccount";
@@ -60,7 +62,13 @@ const UserList: React.VFC<Props> = ({ userAccountList }) => (
             boxShadow: 3,
           }}
         >
-          <ListItem>
+          <ListItem
+            secondaryAction={
+              <IconButton edge="end" disabled>
+                <StarsIcon />
+              </IconButton>
+            }
+          >
             <ListItemAvatar>
               <Avatar sx={{ color: "white" }}>
                 <PersonIcon />

--- a/src/components/UserList.tsx
+++ b/src/components/UserList.tsx
@@ -1,36 +1,64 @@
 import React from "react";
+import Box from "@mui/material/Box";
 import List from "@mui/material/List";
 import ListItem from "@mui/material/ListItem";
 import ListItemText from "@mui/material/ListItemText";
-import ListSubheader from "@mui/material/ListSubheader";
+import ListItemAvatar from "@mui/material/ListItemAvatar";
+import Avatar from "@mui/material/Avatar";
+import ImageIcon from "@mui/icons-material/Image";
+import WorkIcon from "@mui/icons-material/Work";
+import theme from "../styles";
 
 const UserList = () => (
-  <List
+  <Box
+    display="flex"
+    justifyContent="center"
+    alignItems="center"
+    flexDirection="column"
     sx={{
       height: { xs: "90%", sm: "100%" },
       width: "90%",
       borderRadius: "1rem",
-      bgcolor: "background.paper",
-      position: "relative",
-      overflow: "auto",
       boxShadow: 3,
-      "& ul": { p: 2 },
     }}
-    subheader={<li />}
   >
-    {[0, 1, 2, 3, 4].map((sectionId) => (
-      <li key={`section-${sectionId}`}>
-        <ul>
-          <ListSubheader>{`I'm sticky ${sectionId}`}</ListSubheader>
-          {[0, 1, 2].map((item) => (
-            <ListItem key={`item-${sectionId}-${item}`}>
-              <ListItemText primary={`Item ${item}`} />
-            </ListItem>
-          ))}
-        </ul>
-      </li>
-    ))}
-  </List>
+    <Box sx={{ p: 1 }}>プレイヤー</Box>
+    <Box
+      sx={{
+        height: "100%",
+        width: "90%",
+        borderRadius: "1rem",
+        pb: 1,
+      }}
+    >
+      <List
+        sx={{
+          height: "100%",
+          borderRadius: "1rem",
+          bgcolor: theme.palette.success.main,
+          position: "relative",
+          overflow: "auto",
+        }}
+      >
+        <ListItem>
+          <ListItemAvatar>
+            <Avatar sx={{ color: "white" }}>
+              <ImageIcon />
+            </Avatar>
+          </ListItemAvatar>
+          <ListItemText primary="ホスト" />
+        </ListItem>
+        <ListItem>
+          <ListItemAvatar>
+            <Avatar sx={{ color: "white" }}>
+              <WorkIcon />
+            </Avatar>
+          </ListItemAvatar>
+          <ListItemText primary="Work" />
+        </ListItem>
+      </List>
+    </Box>
+  </Box>
 );
 
 export default UserList;

--- a/src/components/UserList.tsx
+++ b/src/components/UserList.tsx
@@ -7,8 +7,13 @@ import ListItemAvatar from "@mui/material/ListItemAvatar";
 import Avatar from "@mui/material/Avatar";
 import PersonIcon from "@mui/icons-material/Person";
 import theme from "../styles";
+import UserAccount from "./UserAccount";
 
-const UserList = () => (
+type Props = {
+  userAccountList: { id: number; userName: string }[];
+};
+
+const UserList: React.VFC<Props> = ({ userAccountList }) => (
   <Box
     display="flex"
     justifyContent="center"
@@ -64,6 +69,9 @@ const UserList = () => (
             <ListItemText primary="ホスト" />
           </ListItem>
         </Box>
+        {userAccountList.map((user) => (
+          <UserAccount userName={user.userName} />
+        ))}
       </List>
     </Box>
   </Box>

--- a/src/components/UserList.tsx
+++ b/src/components/UserList.tsx
@@ -12,7 +12,7 @@ import theme from "../styles";
 import UserAccount from "./UserAccount";
 
 type Props = {
-  userAccountList: { id: number; userName: string }[];
+  userAccountList: { userName: string }[];
 };
 
 const UserList: React.VFC<Props> = ({ userAccountList }) => (

--- a/src/components/UserList.tsx
+++ b/src/components/UserList.tsx
@@ -5,8 +5,7 @@ import ListItem from "@mui/material/ListItem";
 import ListItemText from "@mui/material/ListItemText";
 import ListItemAvatar from "@mui/material/ListItemAvatar";
 import Avatar from "@mui/material/Avatar";
-import ImageIcon from "@mui/icons-material/Image";
-import WorkIcon from "@mui/icons-material/Work";
+import PersonIcon from "@mui/icons-material/Person";
 import theme from "../styles";
 
 const UserList = () => (
@@ -22,40 +21,49 @@ const UserList = () => (
       boxShadow: 3,
     }}
   >
-    <Box sx={{ p: 1 }}>プレイヤー</Box>
     <Box
       sx={{
-        height: "100%",
+        height: "10%",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        fontSize: "1.5rem",
+      }}
+    >
+      プレイヤーリスト
+    </Box>
+    <Box
+      sx={{
+        height: "90%",
         width: "90%",
-        borderRadius: "1rem",
         pb: 1,
       }}
     >
       <List
         sx={{
           height: "100%",
-          borderRadius: "1rem",
-          bgcolor: theme.palette.success.main,
           position: "relative",
           overflow: "auto",
         }}
       >
-        <ListItem>
-          <ListItemAvatar>
-            <Avatar sx={{ color: "white" }}>
-              <ImageIcon />
-            </Avatar>
-          </ListItemAvatar>
-          <ListItemText primary="ホスト" />
-        </ListItem>
-        <ListItem>
-          <ListItemAvatar>
-            <Avatar sx={{ color: "white" }}>
-              <WorkIcon />
-            </Avatar>
-          </ListItemAvatar>
-          <ListItemText primary="Work" />
-        </ListItem>
+        <Box
+          sx={{
+            bgcolor: theme.palette.success.main,
+            m: 1,
+            p: 1,
+            borderRadius: "1rem",
+            boxShadow: 3,
+          }}
+        >
+          <ListItem>
+            <ListItemAvatar>
+              <Avatar sx={{ color: "white" }}>
+                <PersonIcon />
+              </Avatar>
+            </ListItemAvatar>
+            <ListItemText primary="ホスト" />
+          </ListItem>
+        </Box>
       </List>
     </Box>
   </Box>

--- a/src/pages/Lobby.tsx
+++ b/src/pages/Lobby.tsx
@@ -59,12 +59,12 @@ const Lobby: React.VFC<Props> = (props) => {
   }, [roomId]);
 
   const userAccountList = [
-    { id: 1, userName: "ゲスト1" },
-    { id: 2, userName: "ゲスト2" },
-    { id: 3, userName: "ゲスト3" },
-    { id: 4, userName: "ゲスト4" },
-    { id: 5, userName: "ゲスト5" },
-    { id: 6, userName: "ゲスト6" },
+    { userName: "ゲスト1" },
+    { userName: "ゲスト2" },
+    { userName: "ゲスト3" },
+    { userName: "ゲスト4" },
+    { userName: "ゲスト5" },
+    { userName: "ゲスト6" },
   ];
   return (
     <ThemeProvider theme={theme}>
@@ -102,7 +102,9 @@ const Lobby: React.VFC<Props> = (props) => {
                 display: { xs: "block", sm: "none" },
               }}
             >
-              <Typography variant="h5">Oekaki App</Typography>
+              <Typography variant="h5" sx={{ fontFamily: ["Neonderthaw", "cursive"].join(",") }}>
+                Oekaki App
+              </Typography>
             </Box>
             <UserList userAccountList={userAccountList} />
           </Box>
@@ -125,7 +127,9 @@ const Lobby: React.VFC<Props> = (props) => {
               display: { xs: "none", sm: "block" },
             }}
           >
-            <Typography variant="h3">Oekaki App</Typography>
+            <Typography variant="h3" sx={{ fontFamily: ["Neonderthaw", "cursive"].join(",") }}>
+              Oekaki App
+            </Typography>
           </Box>
           <Box display="flex">
             <Box sx={{ pr: 1 }}>

--- a/src/pages/Lobby.tsx
+++ b/src/pages/Lobby.tsx
@@ -58,6 +58,14 @@ const Lobby: React.VFC<Props> = (props) => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [roomId]);
 
+  const userAccountList = [
+    { id: 1, userName: "ゲスト1" },
+    { id: 2, userName: "ゲスト2" },
+    { id: 3, userName: "ゲスト3" },
+    { id: 4, userName: "ゲスト4" },
+    { id: 5, userName: "ゲスト5" },
+    { id: 6, userName: "ゲスト6" },
+  ];
   return (
     <ThemeProvider theme={theme}>
       <CssBaseline />
@@ -96,7 +104,7 @@ const Lobby: React.VFC<Props> = (props) => {
             >
               <Typography variant="h5">Oekaki App</Typography>
             </Box>
-            <UserList />
+            <UserList userAccountList={userAccountList} />
           </Box>
         </Grid>
         <Grid

--- a/src/pages/Top.tsx
+++ b/src/pages/Top.tsx
@@ -39,7 +39,9 @@ const Top = () => (
           }}
         >
           <Box sx={{ pb: 5 }}>
-            <Typography variant="h2">Oekaki App</Typography>
+            <Typography variant="h2" sx={{ fontFamily: ["Neonderthaw", "cursive"].join(",") }}>
+              Oekaki App
+            </Typography>
             <Typography>みんなで遊ぼう！お絵かきアプリ！</Typography>
           </Box>
           <LoginButton />

--- a/src/styles/index.ts
+++ b/src/styles/index.ts
@@ -1,9 +1,9 @@
 import { createTheme } from "@mui/material/styles";
 
 const theme = createTheme({
-  typography: {
-    fontFamily: ["Neonderthaw", "cursive"].join(","),
-  },
+  // typography: {
+  //   fontFamily: ["Neonderthaw", "cursive"].join(","),
+  // },
   palette: {
     background: {
       default: "#eafdb4",


### PR DESCRIPTION
## image
<img width="900" alt="スクリーンショット 2022-01-31 15 44 39" src="https://user-images.githubusercontent.com/95117796/151750115-adbd9772-4691-42c1-bf76-96c538cdbf13.png">

## 概要
プレイヤーリストの見た目を変更しました。

## 補足
ユーザーの情報は取り敢えず作っただけなので、変更予定ありです。

### 最後のcommitについて
アプリ名のfontFamilyをテーマとして設定していましたが、

- アプリ名のみで使用したいフォント
- アプリ名を表示する箇所が少ない
- アプリ名以外の箇所でも適用されてしまう(日本語には適用されないので、例えば"ゲスト1"の1にのみ適用してしまう)

上記3点を理由にテーマから設定を無効にしました。
