### PR TITLE
Feature/#99 add correct answer button

### DIFF
--- a/src/components/CommentLeft.tsx
+++ b/src/components/CommentLeft.tsx
@@ -16,7 +16,7 @@ const CommentLeft: React.VFC<Props> = (props) => {
   return (
     <Stack direction="row" sx={{ width: "100%", py: 2 }}>
       <Avatar>{initialLetter}</Avatar>
-      <Stack direction="row" sx={{ width: "100%", py: 1, pl: 1, alignItems: "center" }}>
+      <Stack direction="row" sx={{ width: "100%", pl: 1, alignItems: "center" }}>
         <Box
           sx={{
             maxWidth: "60%",

--- a/src/components/CommentLeft.tsx
+++ b/src/components/CommentLeft.tsx
@@ -1,9 +1,9 @@
 import React from "react";
 import Avatar from "@mui/material/Avatar";
 import Box from "@mui/material/Box";
-import Button from "@mui/material/Button";
 import Stack from "@mui/material/Stack";
-import CheckIcon from "@mui/icons-material/Check";
+import CorrectButton from "./CorrectButton";
+
 import theme from "../styles";
 
 type Props = {
@@ -32,11 +32,7 @@ const CommentLeft: React.VFC<Props> = (props) => {
         >
           {text}
         </Box>
-        <Box sx={{ width: "1rem", height: "1rem", ml: 1 }}>
-          <Button variant="contained" sx={{ borderRadius: "5em" }}>
-            <CheckIcon />
-          </Button>
-        </Box>
+        <CorrectButton />
       </Stack>
     </Stack>
   );

--- a/src/components/CommentLeft.tsx
+++ b/src/components/CommentLeft.tsx
@@ -1,7 +1,9 @@
 import React from "react";
-import Stack from "@mui/material/Stack";
-import Box from "@mui/material/Box";
 import Avatar from "@mui/material/Avatar";
+import Box from "@mui/material/Box";
+import Button from "@mui/material/Button";
+import Stack from "@mui/material/Stack";
+import CheckIcon from "@mui/icons-material/Check";
 import theme from "../styles";
 
 type Props = {
@@ -14,14 +16,14 @@ const CommentLeft: React.VFC<Props> = (props) => {
   return (
     <Stack direction="row" sx={{ width: "100%", py: 2 }}>
       <Avatar>{initialLetter}</Avatar>
-      <Box sx={{ width: "100%", pt: 2, pl: 2, display: "flex" }}>
+      <Stack direction="row" sx={{ width: "100%", py: 1, pl: 1, alignItems: "center" }}>
         <Box
           sx={{
-            maxWidth: "70%",
+            maxWidth: "60%",
             borderRadius: 16,
             bgcolor: theme.palette.background.default,
             textAlign: "start",
-            py: 2,
+            py: 1,
             px: 3,
             display: "flex",
             alignItems: "center",
@@ -30,7 +32,12 @@ const CommentLeft: React.VFC<Props> = (props) => {
         >
           {text}
         </Box>
-      </Box>
+        <Box sx={{ width: "1rem", height: "1rem", ml: 1 }}>
+          <Button variant="contained" sx={{ borderRadius: "5em" }}>
+            <CheckIcon />
+          </Button>
+        </Box>
+      </Stack>
     </Stack>
   );
 };

--- a/src/components/CorrectButton.tsx
+++ b/src/components/CorrectButton.tsx
@@ -2,10 +2,11 @@ import React from "react";
 import Box from "@mui/material/Box";
 import CheckIcon from "@mui/icons-material/Check";
 import Button from "@mui/material/Button";
+import theme from "../styles";
 
 const CorrectButton = () => (
   <Box sx={{ width: "1rem", ml: 1 }}>
-    <Button variant="contained" sx={{ borderRadius: "5em" }}>
+    <Button variant="contained" sx={{ borderRadius: "5em", bgcolor: theme.palette.secondary.main }}>
       <CheckIcon />
     </Button>
   </Box>

--- a/src/components/CorrectButton.tsx
+++ b/src/components/CorrectButton.tsx
@@ -4,7 +4,7 @@ import CheckIcon from "@mui/icons-material/Check";
 import Button from "@mui/material/Button";
 
 const CorrectButton = () => (
-  <Box sx={{ width: "1rem", height: "1rem", ml: 1 }}>
+  <Box sx={{ width: "1rem", ml: 1 }}>
     <Button variant="contained" sx={{ borderRadius: "5em" }}>
       <CheckIcon />
     </Button>

--- a/src/components/CorrectButton.tsx
+++ b/src/components/CorrectButton.tsx
@@ -1,0 +1,14 @@
+import React from "react";
+import Box from "@mui/material/Box";
+import CheckIcon from "@mui/icons-material/Check";
+import Button from "@mui/material/Button";
+
+const CorrectButton = () => (
+  <Box sx={{ width: "1rem", height: "1rem", ml: 1 }}>
+    <Button variant="contained" sx={{ borderRadius: "5em" }}>
+      <CheckIcon />
+    </Button>
+  </Box>
+);
+
+export default CorrectButton;


### PR DESCRIPTION
## 正解ボタンを作成しました

- カラーは新しい色を使おうかと考えましたが、統一性がなくなると考えtenさんが設定してくださっているsecondary.mainを使用しました。

<img width="1713" alt="スクリーンショット 2022-02-01 12 47 28" src="https://user-images.githubusercontent.com/78239360/151910122-645131b0-8df7-419c-8b81-bae0924d84bc.png">
